### PR TITLE
remove gcc version dependencies

### DIFF
--- a/Makefile.Linux
+++ b/Makefile.Linux
@@ -1,5 +1,6 @@
 CFLAGS = -O2
 CFLAGS += -pie
+CFLAGS += -static-libgcc -static-libstdc++ -ftls-model=global-dynamic
 CFLAGS += -I/usr/include/SDL2
 CFLAGS += -I/usr/local/include/SDL2
 CFLAGS += -I/opt/X11/include


### PR DESCRIPTION
Reflect the points made in the following threads.

https://steamcommunity.com/app/2824990/discussions/0/4355617421470222247/

Added following options for Linux

- `-static-libgcc` will dodge libgcc ABI issues (which are common)
- `-static-libstdc++` will dodge c++ ABI issues (which are legions and happening all the time)
- `-ftls-model=global-dynamic` will spare ELF static TLS slots for system libs (because they are somewhat rare).